### PR TITLE
fix: resolve column name handling for postgres

### DIFF
--- a/api/src/controllers/exports.controller.ts
+++ b/api/src/controllers/exports.controller.ts
@@ -3,7 +3,6 @@ import { AuthGuard } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Request, Response } from 'express';
 import { Repository } from 'typeorm';
-import { config } from '../config'
 import { ProjectAction } from '../domain/actions';
 import { IntermediateTranslationFormat } from '../domain/formatters';
 import { ExportQuery, ImportExportFormat } from '../domain/http';

--- a/api/src/controllers/exports.controller.ts
+++ b/api/src/controllers/exports.controller.ts
@@ -3,6 +3,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Request, Response } from 'express';
 import { Repository } from 'typeorm';
+import { config } from '../config'
 import { ProjectAction } from '../domain/actions';
 import { IntermediateTranslationFormat } from '../domain/formatters';
 import { ExportQuery, ImportExportFormat } from '../domain/http';
@@ -23,6 +24,7 @@ import { ApiOAuth2, ApiTags, ApiOperation, ApiProduces, ApiResponse } from '@nes
 import { androidXmlExporter } from '../formatters/android-xml';
 import { resXExporter } from '../formatters/resx';
 import { merge } from 'lodash';
+import { resolveColumnName } from '../utils/alias-helper';
 
 @Controller('api/v1/projects/:projectId/exports')
 export class ExportsController {
@@ -69,10 +71,10 @@ export class ExportsController {
 
     const queryBuilder = this.termRepo
       .createQueryBuilder('term')
-      .leftJoinAndSelect('term.translations', 'translation', 'translation.projectLocaleId = :projectLocaleId', {
+      .leftJoinAndSelect('term.translations', 'translation', `translation.${resolveColumnName('projectLocaleId')} = :projectLocaleId`, {
         projectLocaleId: projectLocale.id,
       })
-      .where('term.projectId = :projectId', { projectId })
+      .where(`term.${resolveColumnName('projectId')} = :projectId`, { projectId })
       .orderBy('term.value', 'ASC');
 
     if (query.untranslated) {
@@ -112,10 +114,10 @@ export class ExportsController {
       if (fallbackProjectLocale) {
         const fallbackTermsWithTranslations = await this.termRepo
           .createQueryBuilder('term')
-          .leftJoinAndSelect('term.translations', 'translation', 'translation.projectLocaleId = :projectLocaleId', {
+          .leftJoinAndSelect('term.translations', 'translation', `translation.${resolveColumnName('projectLocaleId')} = :projectLocaleId`, {
             projectLocaleId: fallbackProjectLocale.id,
           })
-          .where('term.projectId = :projectId', { projectId })
+          .where(`term.${resolveColumnName('projectId')} = :projectId`, { projectId })
           .orderBy('term.value', 'ASC')
           .getMany();
 

--- a/api/src/controllers/project-stats.controller.ts
+++ b/api/src/controllers/project-stats.controller.ts
@@ -50,7 +50,7 @@ export default class ProjectStatsController {
       .leftJoin(`${resolveColumnName('projectLocale')}.translations`, 'translations')
       .select(`${resolveColumnName('projectLocale')}.${resolveColumnName('localeCode')}`, 'localeCode')
       .addSelect('count(*)', 'translated')
-      .groupBy(`${resolveColumnName('projectLocale')}.${resolveColumnName('localeCode')}`)
+      .groupBy(resolveColumnName('localeCode'))
       .whereInIds(locales.map(l => l.id))
       .andWhere("translations.value <> ''")
       .execute();

--- a/api/src/utils/alias-helper.ts
+++ b/api/src/utils/alias-helper.ts
@@ -4,10 +4,14 @@ import { config } from '../config';
 // TypeORM fails to properly quote camelCase aliases with PostgreSQL
 // https://github.com/typeorm/typeorm/issues/10961
 export const resolveColumnName = (columnName: string): string => {
-  // Convert the column name to snake_case if needed
+  if (!columnName) {
+    throw new Error('Column name cannot be empty');
+  }
+
+  // convert only for postgres until typeorm has a fix
   if (config.db.default.type === 'postgres') {
     return snakeCase(columnName);
   }
 
   return columnName;
-}
+};

--- a/api/src/utils/alias-helper.ts
+++ b/api/src/utils/alias-helper.ts
@@ -1,0 +1,13 @@
+import { snakeCase } from 'typeorm/util/StringUtils';
+import { config } from '../config';
+
+// TypeORM fails to properly quote camelCase aliases with PostgreSQL
+// https://github.com/typeorm/typeorm/issues/10961
+export const resolveColumnName = (columnName: string): string => {
+  // Convert the column name to snake_case if needed
+  if (config.db.default.type === 'postgres') {
+    return snakeCase(columnName);
+  }
+
+  return columnName;
+}


### PR DESCRIPTION
This PR addresses an issue raised in #390 , where TypeORM fails to properly quote camelCase aliases in PostgreSQL, leading to errors when querying project statistics and exports endpoint. TypeORM has several open issues, including ([https://github.com/typeorm/typeorm/issues/10961](https://github.com/typeorm/typeorm/issues/10961)), related to camelCase alias handling in PostgreSQL that remain unresolved.

As a temporary workaround, this PR replaces camelCase aliases with snake_case until TypeORM provides a permanent fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a utility function to dynamically resolve database column names, enhancing query flexibility.
- **Improvements**
	- Updated SQL query handling in the export and project stats functionalities for better maintainability.
- **Bug Fixes**
	- Addressed issues with column naming conventions in PostgreSQL to ensure proper query execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->