### PR TITLE
[Fix] #450 Hide Google provider if `TR_AUTH_GOOGLE_ENABLED` env var is not set to "true"

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -26,7 +26,7 @@ export const config = {
   },
   providers: {
     google: {
-      active: env.TR_AUTH_GOOGLE_ENABLED,
+      active: getBoolOrDefault(env.TR_AUTH_GOOGLE_ENABLED, false),
       clientSecret: env.TR_AUTH_GOOGLE_CLIENT_SECRET,
       clientId: env.TR_AUTH_GOOGLE_CLIENT_ID,
       redirectUrl: env.TR_AUTH_GOOGLE_REDIRECT_URL,


### PR DESCRIPTION
### **Fix: Hide Google Provider When `TR_AUTH_GOOGLE_ENABLED` is "false"**  

**Fixes**: #450  

#### **Description**  
This PR ensures that the Google authentication provider is correctly disabled when `TR_AUTH_GOOGLE_ENABLED` is set to `"false"`. Previously, any string value (including `"false"`) was treated as truthy, causing the provider to remain active despite the environment variable indicating otherwise.  

#### **Changes**  
- Updated the `active` property of the Google provider to use `getBoolOrDefault(env.TR_AUTH_GOOGLE_ENABLED, false)`, ensuring proper boolean evaluation.  

#### **Steps to Reproduce the Issue**  
1. Start the Traduora API service with `TR_AUTH_GOOGLE_ENABLED=false`.  
2. Start the Traduora WebApp.  
3. Navigate to the login page.  
4. The Google login option should now be **hidden** when `TR_AUTH_GOOGLE_ENABLED` is `"false"`.  

#### **Expected Behavior**  
- The Google login provider should be **hidden** when `TR_AUTH_GOOGLE_ENABLED=false`.  
- The Google login provider should be **visible** when `TR_AUTH_GOOGLE_ENABLED=true`.  

#### **Testing**  
- Verified that setting `TR_AUTH_GOOGLE_ENABLED=false` correctly hides the Google login button.  
- Verified that setting `TR_AUTH_GOOGLE_ENABLED=` correctly hides the Google login button.  
- Verified that setting `TR_AUTH_GOOGLE_ENABLED=abc` correctly hides the Google login button.  
- Verified that setting `TR_AUTH_GOOGLE_ENABLED=true` correctly shows the Google login button. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of Google authentication settings by ensuring a reliable default is applied when configuration is absent, reducing potential misconfigurations and enhancing overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->