### PR TITLE
[Fix] Don't attempt to process provider code if provider is disabled

### DIFF
--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -8,7 +8,11 @@ export class AuthService {
   constructor(private readonly httpService: HttpService) {}
 
   async getTokenFromGoogle(code: string): Promise<any> {
-    const { apiUrl, clientId, clientSecret, redirectUrl } = config.providers.google;
+    const { active, apiUrl, clientId, clientSecret, redirectUrl } = config.providers.google;
+
+    if (!active) {
+      throw new BadRequestException();
+    }
 
     try {
       const body = stringify(

--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -11,7 +11,7 @@ export class AuthService {
     const { active, apiUrl, clientId, clientSecret, redirectUrl } = config.providers.google;
 
     if (!active) {
-      throw new BadRequestException();
+      throw new BadRequestException('Google authentication provider is not enabled');
     }
 
     try {


### PR DESCRIPTION
### **Fix: Don't attempt to process provider code if provider is disabled**  

#### **Description**  
This PR ensures that the Google authentication provider does not attempt to process authentication requests when it is disabled. Previously, the service would proceed with code validation and API calls even if `TR_AUTH_GOOGLE_ENABLED=false`, leading to unnecessary requests and potential errors. 

#### **Changes**  
- Added a check for `active` status in the `getTokenFromGoogle` method.  
- If the provider is **disabled**, an immediate `BadRequestException` is thrown to prevent further processing.  

#### **Fixes**  
- Prevents unnecessary API requests when the provider is disabled.  
- Improves security by ensuring no token exchange occurs for a disabled provider.  
- Enhances consistency with the expected behavior of `TR_AUTH_GOOGLE_ENABLED=false`.  

#### **Testing**  
- Verified that when `TR_AUTH_GOOGLE_ENABLED=false` (with #451), the service **immediately throws a BadRequestException** instead of making an API call.  
- Verified that when `TR_AUTH_GOOGLE_ENABLED=true`, the authentication flow functions as expected.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Google sign-in process to verify that the service is enabled before processing requests. Users attempting to log in via Google when the feature is disabled will now receive a clear error, ensuring a more reliable and consistent authentication experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->